### PR TITLE
update staticcheck to 2023.1.3 (v0.4.3)

### DIFF
--- a/packages/staticcheck/package.yaml
+++ b/packages/staticcheck/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:golang/honnef.co/go/tools/cmd/staticcheck@v0.3.3
+  id: pkg:golang/honnef.co/go/tools/cmd/staticcheck@2023.1.3
 
 bin:
   staticcheck: golang:staticcheck


### PR DESCRIPTION
See https://github.com/dominikh/go-tools/releases for information about the last several releases